### PR TITLE
Fix Change Month Test to account for November and December

### DIFF
--- a/src/classes/calendar/index.test.ts
+++ b/src/classes/calendar/index.test.ts
@@ -499,13 +499,19 @@ describe("Calendar Class Tests", () => {
         const curVisYear = tCal.year.visibleYear;
         tCal.changeMonth(tCal.months.length + 1);
         expect(tCal.months[(d.getMonth() + 2) % tCal.months.length].visible).toBe(true);
-        expect(tCal.year.visibleYear).toBe(curVisYear + 1);
+        if (d.getMonth() < 10)
+            expect(tCal.year.visibleYear).toBe(curVisYear + 1);
+        else
+            expect(tCal.year.visibleYear).toBe(curVisYear + 2);
 
         tCal.resetMonths("visible");
         tCal.months[10].visible = true;
         tCal.changeMonth(-1 * tCal.months.length);
         expect(tCal.months[10].visible).toBe(true);
-        expect(tCal.year.visibleYear).toBe(curVisYear);
+        if (d.getMonth() < 10)
+            expect(tCal.year.visibleYear).toBe(curVisYear);
+        else
+            expect(tCal.year.visibleYear).toBe(curVisYear+1);
     });
 
     test("Change Day Current", () => {


### PR DESCRIPTION
Existing test fails in the months of November and December because the test did not account for the fact advancing forward 14 months can change the calendar year twice instead of once. Added logic to account for the double year change, test is now passing.