### PR TITLE
Fixed GH-24 by adding logic to convert null to "null" to fix the Starting Weekday dropdown in settings

### DIFF
--- a/src/classes/applications/configuration-app.ts
+++ b/src/classes/applications/configuration-app.ts
@@ -284,7 +284,9 @@ export default class ConfigurationApp extends FormApplication {
                 custom: "FSC.Configuration.LeapYear.Rules.Custom"
             },
             months: (<Calendar>this.object).months.map((m) => {
-                return m.toTemplate();
+                const mt = m.toTemplate();
+                mt.startingWeekday = mt.startingWeekday === null ? "null" : mt.startingWeekday.toString();
+                return mt;
             }),
             monthStartingWeekdays: <{ [key: string]: string }>{},
             moons: (<Calendar>this.object).moons.map((m) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1456,7 +1456,7 @@ declare global {
                 intercalary: boolean;
                 intercalaryInclude: boolean;
                 showAdvanced: boolean;
-                startingWeekday: number | null;
+                startingWeekday: number | string | null;
             }
 
             /**


### PR DESCRIPTION
Fixes #24 

`startingWeekday` defaults to `null` when unset, and is the desired setting 99% of the time. However, we cannot use `null` as an index for the combo box, so the previous logic used "null" for the default value in the combobox. While the previous implementation correctly converted "null" to `null` when saving the values to the config, there was no conversion when reading the value from the config. This commit adds logic to the mapping function for months to convert `null` to "null" so that the combo box is able to correctly understand and set that value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar month template data processing to properly normalize the starting weekday field for consistent template rendering. The field is now correctly formatted in all scenarios, improving template compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->