### PR TITLE
Fix GH-28: Prevent unnecessary calendar redraws by comparing date changes

### DIFF
--- a/src/classes/calendar/calendar-manager.ts
+++ b/src/classes/calendar/calendar-manager.ts
@@ -64,6 +64,7 @@ export default class CalendarManager {
      * @returns {number} The number of calendars loaded
      */
     public loadCalendars(): number {
+        const origDate = this.getVisibleCalendar()?.getCurrentDate();
         const calendars = <SimpleCalendar.CalendarData[]>GameSettings.GetObjectSettings(SettingNames.CalendarConfiguration);
         //Default array is being returned with an empty string, if this is the case we need to return that empty string to get an empty array
         if (calendars.length === 1 && !calendars[0]) {
@@ -87,8 +88,17 @@ export default class CalendarManager {
         }
         NManager.checkNoteTriggers(this.activeId);
         const cal = this.getVisibleCalendar();
+        // Check to see if the time keeper is running, if so we dont want to fully redraw.
         if (cal && cal.timeKeeper.getStatus() !== TimeKeeperStatus.Started) {
-            MainApplication.updateApp();
+            // Additionally, real time clocks can be being handled by external systems and can trigger reloads
+            // as often as every second, like Shadowdark, we dont want to fully redraw the calendar if only the time has changed.
+            // Fixes issue GH-28
+            if (origDate) {
+                const currDate = cal.getCurrentDate();
+                if (currDate.year !== origDate.year || currDate.month !== origDate.month || currDate.day !== origDate.day) {
+                    MainApplication.updateApp();
+                }
+            } else MainApplication.updateApp();
         }
         return Object.keys(this.calendars).length;
     }

--- a/src/classes/calendar/index.ts
+++ b/src/classes/calendar/index.ts
@@ -667,8 +667,8 @@ export default class Calendar extends ConfigurationItemBase {
             verifiedSetting === "current"
                 ? this.year.numericRepresentation
                 : verifiedSetting === "visible"
-                ? this.year.visibleYear
-                : this.year.selectedYear;
+                  ? this.year.visibleYear
+                  : this.year.selectedYear;
         const isLeapYear = this.year.leapYearRule.isLeapYear(yearToUse);
         if (month === -1 || month >= this.months.length) {
             month = this.months.length - 1;
@@ -1251,6 +1251,7 @@ export default class Calendar extends ConfigurationItemBase {
                 // If the current player is the GM then we need to save this new value to the database
                 // Since the current date is updated this will trigger an update on all players as well
                 this.setDateTime(parsedDate, { updateApp: false, sync: false, save: GameSettings.IsGm() && SC.primary });
+                Renderer.Clock.UpdateListener(`sc_${this.id}_clock`, this.timeKeeper.getStatus());
             }
         }
         this.timeChangeTriggered = false;


### PR DESCRIPTION
- Added logic to avoid full redraw of the calendar when only time changes, particularly for real-time clocks.
Fixes #28 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clock synchronization so the on-screen clock updates correctly when the calendar time is changed by external sources (covers an additional update path).

* **Refactor**
  * Optimized calendar reloads to avoid full screen redraws when the visible date is unchanged, while preserving prior update behavior when the original date is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->