### PR TITLE
Foundry v14 compatibility added, older versions deprecated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundryvtt-simple-calendar-reborn",
   "description": "A simple calendar module for keeping track of game days and events. Forked from the original Simple Calendar by Vigoren.",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "author": "Arctis Fireblight, Dean Vigoren (Vigorator)",
   "keywords": [
     "foundryvtt",

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
 	"id": "foundryvtt-simple-calendar-reborn",
 	"title": "Simple Calendar Reborn",
 	"description": "A simple calendar module for keeping track of game days and events. Forked from the original Simple Calendar by Vigoren.",
-	"version": "2.5.4",
+	"version": "2.6.0",
 	"authors": [
       {
         "name": "Arctis Fireblight",
@@ -18,8 +18,8 @@
       }
 	],
 	"compatibility": {
-		"minimum": "13",
-		"verified": "13"
+		"minimum": "14",
+		"verified": "14"
 	},
 	"url": "https://github.com/Fireblight-Studios/foundryvtt-simple-calendar",
 	"bugs": "https://github.com/Fireblight-Studios/foundryvtt-simple-calendar/issues",

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -2,8 +2,8 @@
 @import "mixin/scrollbar";
 
 $font-family: 'Roboto', sans-serif;
-$icon-font-family: var(--fa-style-family,"Font Awesome 6 Pro");
-$icon-font-family-brands: var(--fa-style-family,"Font Awesome 6 Brands");
+$icon-font-family: var(--fa-style-family,"Font Awesome 7 Pro");
+$icon-font-family-brands: var(--fa-style-family,"Font Awesome 7 Brands");
 
 $spacer-half: $spacer * 0.5;       //8px
 $spacer-quarter: $spacer-half * 0.5;    //4px


### PR DESCRIPTION
Fixes #38 by updating Font Awesome from version 6 to 7, as Foundry v14 uses the newer version. Unfortunately this seems to break compatibility with versions 13 and older so I will need to drop support for those versions. Inremented the minor version of the package as well to signify the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.6.0.
  * Updated compatibility to support Foundry VTT version 14.
  * Upgraded icon library to Font Awesome 7 Pro and Brands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->