### PR TITLE
Fix GH-41: Improve calendar import logic and ID mapping when creating new calendars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundryvtt-simple-calendar-reborn",
   "description": "A simple calendar module for keeping track of game days and events. Forked from the original Simple Calendar by Vigoren.",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "author": "Arctis Fireblight, Dean Vigoren (Vigorator)",
   "keywords": [
     "foundryvtt",

--- a/src/classes/applications/configuration-app.ts
+++ b/src/classes/applications/configuration-app.ts
@@ -1807,6 +1807,7 @@ export default class ConfigurationApp extends FormApplication {
             ) {
                 this.globalConfiguration.permissions.loadFromSettings(data.permissions);
             }
+            const idLookupTable: Record<string, string> = {};
             if (Object.prototype.hasOwnProperty.call(data, "calendars") && data.calendars.length) {
                 //Ensure that the note directory exists and is correct
                 await NManager.createJournalDirectory();
@@ -1826,12 +1827,17 @@ export default class ConfigurationApp extends FormApplication {
                         const importCalendar = this.calendars.find((c) => {
                             return c.id === importInto;
                         });
+                        // Record the original id just in case we need to look it up later
+                        const originalId = data.calendars[i].id;
                         delete data.calendars[i].id;
                         if (importCalendar) {
                             importCalendar.loadFromSettings(data.calendars[i]);
                         } else {
                             const newCalendar = CalManager.addTempCalendar(data.calendars[i].name);
                             newCalendar.loadFromSettings(data.calendars[i]);
+                            this.calendars.push(newCalendar);
+                            // map the old and new IDs so that notes can be mapped to the correct calendar later.
+                            idLookupTable[originalId] = newCalendar.id;
                         }
                     }
                 }
@@ -1850,11 +1856,16 @@ export default class ConfigurationApp extends FormApplication {
                         )
                     )
                         continue;
-                    const importInto = getTextInputValue(
+                    let importInto = getTextInputValue(
                         `.fsc-import-export .fsc-importing .fsc-file-details select[data-for-cal="${calId}"]`,
                         calId,
                         this.appWindow
-                    );
+                    ).replace("_temp", ""); // Sometimes will have "_temp" appended, need to normalize (GH-41)
+                    // Handle the case where the user wants to import into a new calendar
+                    if (importInto === "new") {
+                        importInto = idLookupTable[calId].replace("_temp", "");
+                        console.log(`Importing notes into new calendar: ${importInto}`);
+                    }
                     const importCalendar = this.calendars.find((c) => {
                         return c.id.replace("_temp", "") === importInto;
                     });

--- a/src/classes/applications/configuration-app.ts
+++ b/src/classes/applications/configuration-app.ts
@@ -1759,7 +1759,7 @@ export default class ConfigurationApp extends FormApplication {
                                 })?.name || key
                             }</strong>: ${GameSettings.Localize("FSC.CalendarNotes")}</label></label>`;
 
-                            html += `<label>${GameSettings.Localize("FSC.ImportInto")}:&nbsp;<select data-for-cal="">`;
+                            html += `<label>${GameSettings.Localize("FSC.ImportInto")}:&nbsp;<select data-for-cal="${key}">`;
                             const selectedIndex = this.calendars.findIndex((c) => {
                                 return c.id.indexOf(key) === 0;
                             });
@@ -1863,7 +1863,12 @@ export default class ConfigurationApp extends FormApplication {
                     ).replace("_temp", ""); // Sometimes will have "_temp" appended, need to normalize (GH-41)
                     // Handle the case where the user wants to import into a new calendar
                     if (importInto === "new") {
-                        importInto = idLookupTable[calId].replace("_temp", "");
+                        const mappedCalendarId = idLookupTable[calId];
+                        if (!mappedCalendarId) {
+                            console.warn(`Skipping notes for ${calId}: no new calendar was created for this import target.`);
+                            continue;
+                        }
+                        importInto = mappedCalendarId.replace("_temp", "");
                         console.log(`Importing notes into new calendar: ${importInto}`);
                     }
                     const importCalendar = this.calendars.find((c) => {

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
 	"id": "foundryvtt-simple-calendar-reborn",
 	"title": "Simple Calendar Reborn",
 	"description": "A simple calendar module for keeping track of game days and events. Forked from the original Simple Calendar by Vigoren.",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"authors": [
       {
         "name": "Arctis Fireblight",


### PR DESCRIPTION
Fixes #41 
- Added a lookup table to map old and new calendar IDs during imports.
- Handled cases where calendar IDs include "_temp" and normalized them.
- Ensured creation of new calendars and proper mapping of notes if "new" is selected during import.
- Bumped version to v2.6.1 for an immediate release after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar import to correctly target notes when importing into new calendars.
  * Fixed temporary calendar identifier handling during import operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->